### PR TITLE
Fix the low volume issues on galaxy s2

### DIFF
--- a/configs/tinyalsa-audio.xml
+++ b/configs/tinyalsa-audio.xml
@@ -57,21 +57,25 @@
 		</device>
 		<device type="wired-headphone">
 			<path type="enable">
-				<ctrl name="Headphone Playback Volume" value="15" />
+				<ctrl name="Headphone Playback Volume" value="16" />
+				<ctrl name="HP Gain Playback Volume" value="3" />
 				<ctrl name="Headphone Playback Switch" value="on" />
 			</path>
 			<path type="disable">
 				<ctrl name="Headphone Playback Volume" value="0" />
+				<ctrl name="HP Gain Playback Volume" value="0" />
 				<ctrl name="Headphone Playback Switch" value="off" />
 			</path>
 		</device>
 		<device type="wired-headset">
 			<path type="enable">
-				<ctrl name="Headphone Playback Volume" value="15" />
+				<ctrl name="Headphone Playback Volume" value="16" />
+				<ctrl name="HP Gain Playback Volume" value="3" />
 				<ctrl name="Headphone Playback Switch" value="on" />
 			</path>
 			<path type="disable">
 				<ctrl name="Headphone Playback Volume" value="0" />
+				<ctrl name="HP Gain Playback Volume" value="0" />
 				<ctrl name="Headphone Playback Switch" value="off" />
 			</path>
 		</device>


### PR DESCRIPTION
Incrementing Headphone Playback Volume usually result in distortion specially with music that is already compressed.
- Added Gain 3 == 6dB 
  should fix low headphone volumes once and for all..
