### PR TITLE
Fix for headphone volume (nearer to the stock ROM behaviour)

### DIFF
--- a/configs/tinyalsa-audio.xml
+++ b/configs/tinyalsa-audio.xml
@@ -57,25 +57,21 @@
 		</device>
 		<device type="wired-headphone">
 			<path type="enable">
-				<ctrl name="Headphone Playback Volume" value="15" />
-				<ctrl name="HP Gain Playback Volume" value="3" />
+				<ctrl name="Headphone Playback Volume" value="31" />
 				<ctrl name="Headphone Playback Switch" value="on" />
 			</path>
 			<path type="disable">
 				<ctrl name="Headphone Playback Volume" value="0" />
-				<ctrl name="HP Gain Playback Volume" value="0" />
 				<ctrl name="Headphone Playback Switch" value="off" />
 			</path>
 		</device>
 		<device type="wired-headset">
 			<path type="enable">
-				<ctrl name="Headphone Playback Volume" value="15" />
-				<ctrl name="HP Gain Playback Volume" value="3" />
+				<ctrl name="Headphone Playback Volume" value="31" />
 				<ctrl name="Headphone Playback Switch" value="on" />
 			</path>
 			<path type="disable">
 				<ctrl name="Headphone Playback Volume" value="0" />
-				<ctrl name="HP Gain Playback Volume" value="0" />
 				<ctrl name="Headphone Playback Switch" value="off" />
 			</path>
 		</device>


### PR DESCRIPTION
Regarding the low volume issue I think the good way to amplify the headphone volume is to set the Headphone Playback Volume to 31 rather than changing the HP Gain into 3, as the max value for the Headphone Playback Volume is 31, not 15 as set in the xml file. This method is also used in the stock kernel actually, you can see it from AlsaMixer app available from the Market, and then make sure the phone is rooted
